### PR TITLE
Add batch pipelining for argument processing and sampling for keyspaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/go
+{
+	"name": "Go",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/go:1-1.21-bullseye"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "go version",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/cmd/app/display.go
+++ b/cmd/app/display.go
@@ -2,11 +2,12 @@ package app
 
 import (
 	"encoding/json"
+	"os"
+
 	"github.com/obukhov/redis-inventory/src/logger"
 	"github.com/obukhov/redis-inventory/src/renderer"
 	"github.com/obukhov/redis-inventory/src/trie"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var displayCmd = &cobra.Command{
@@ -18,7 +19,13 @@ var displayCmd = &cobra.Command{
 		consoleLogger := logger.NewConsoleLogger(logLevel)
 		consoleLogger.Info().Msg("Loading index")
 
-		indexFileName := os.TempDir() + "/redis-inventory.json"
+		var indexFileName string
+		if len(args) > 0 {
+			indexFileName = args[0]
+		} else {
+			indexFileName = os.TempDir() + "/redis-inventory.json"
+		}
+
 		f, err := os.Open(indexFileName)
 		if err != nil {
 			consoleLogger.Fatal().Err(err).Msg("Can't create renderer")

--- a/cmd/app/index.go
+++ b/cmd/app/index.go
@@ -75,8 +75,9 @@ func init() {
 	RootCmd.AddCommand(indexCmd)
 	indexCmd.Flags().StringVarP(&logLevel, "logLevel", "l", "info", "Level of logs to be displayed")
 	indexCmd.Flags().StringVarP(&separators, "separators", "s", ":", "Symbols that logically separate levels of the key")
-	indexCmd.Flags().IntVarP(&maxChildren, "maxChildren", "m", 10, "Maximum children node can have before start aggregating")
+	indexCmd.Flags().IntVarP(&maxChildren, "maxChildren", "m", 50, "Maximum children node can have before start aggregating")
+	indexCmd.Flags().IntVarP(&samplePerc, "samplePerc", "p", 10, "Percentage of returned keys to sample")
 	indexCmd.Flags().StringVarP(&pattern, "pattern", "k", "*", "Glob pattern limiting the keys to be aggregated")
-	indexCmd.Flags().IntVarP(&scanCount, "scanCount", "c", 1000, "Number of keys to be scanned in one iteration (argument of scan command)")
+	indexCmd.Flags().IntVarP(&scanCount, "scanCount", "c", 5000, "Number of keys to be scanned in one iteration (argument of scan command)")
 	indexCmd.Flags().IntVarP(&throttleNs, "throttle", "t", 0, "Throttle: number of nanoseconds to sleep between keys")
 }

--- a/cmd/app/index.go
+++ b/cmd/app/index.go
@@ -47,9 +47,10 @@ var indexCmd = &cobra.Command{
 		resultTrie := trie.NewTrie(trie.NewPunctuationSplitter([]rune(separators)...), maxChildren)
 		redisScanner.Scan(
 			adapter.ScanOptions{
-				ScanCount: scanCount,
-				Pattern:   pattern,
-				Throttle:  throttleNs,
+				ScanCount:  scanCount,
+				Pattern:    pattern,
+				Throttle:   throttleNs,
+				SamplePerc: samplePerc,
 			},
 			resultTrie,
 		)
@@ -76,7 +77,7 @@ func init() {
 	indexCmd.Flags().StringVarP(&logLevel, "logLevel", "l", "info", "Level of logs to be displayed")
 	indexCmd.Flags().StringVarP(&separators, "separators", "s", ":", "Symbols that logically separate levels of the key")
 	indexCmd.Flags().IntVarP(&maxChildren, "maxChildren", "m", 50, "Maximum children node can have before start aggregating")
-	indexCmd.Flags().IntVarP(&samplePerc, "samplePerc", "p", 10, "Percentage of returned keys to sample")
+	indexCmd.Flags().IntVarP(&samplePerc, "samplePerc", "n", 10, "Percentage of returned keys to sample")
 	indexCmd.Flags().StringVarP(&pattern, "pattern", "k", "*", "Glob pattern limiting the keys to be aggregated")
 	indexCmd.Flags().IntVarP(&scanCount, "scanCount", "c", 5000, "Number of keys to be scanned in one iteration (argument of scan command)")
 	indexCmd.Flags().IntVarP(&throttleNs, "throttle", "t", 0, "Throttle: number of nanoseconds to sleep between keys")

--- a/cmd/app/inventory.go
+++ b/cmd/app/inventory.go
@@ -43,9 +43,10 @@ var scanCmd = &cobra.Command{
 		resultTrie := trie.NewTrie(trie.NewPunctuationSplitter([]rune(separators)...), maxChildren)
 		redisScanner.Scan(
 			adapter.ScanOptions{
-				ScanCount: scanCount,
-				Pattern:   pattern,
-				Throttle:  throttleNs,
+				ScanCount:  scanCount,
+				Pattern:    pattern,
+				Throttle:   throttleNs,
+				SamplePerc: samplePerc,
 			},
 			resultTrie,
 		)
@@ -70,6 +71,7 @@ func init() {
 	scanCmd.Flags().StringVarP(&outputParams, "output-params", "p", "", "Parameters specific for output type")
 	scanCmd.Flags().StringVarP(&logLevel, "logLevel", "l", "info", "Level of logs to be displayed")
 	scanCmd.Flags().StringVarP(&separators, "separators", "s", ":", "Symbols that logically separate levels of the key")
+	scanCmd.Flags().IntVarP(&samplePerc, "samplePerc", "n", 10, "Percentage of returned keys to sample")
 	scanCmd.Flags().IntVarP(&maxChildren, "maxChildren", "m", 10, "Maximum children node can have before start aggregating")
 	scanCmd.Flags().StringVarP(&pattern, "pattern", "k", "*", "Glob pattern limiting the keys to be aggregated")
 	scanCmd.Flags().IntVarP(&scanCount, "scanCount", "c", 1000, "Number of keys to be scanned in one iteration (argument of scan command)")

--- a/cmd/app/inventory.go
+++ b/cmd/app/inventory.go
@@ -17,12 +17,19 @@ var scanCmd = &cobra.Command{
 	Use:   "inventory redis://[:<password>@]<host>:<port>[/<dbIndex>]",
 	Short: "Scan keys and display summary right away with selected output and output params",
 	Long:  "Scan command builds prefix tree in memory and then displays the usage summary. To avoid scanning redis instance when trying different output formats use `index` and `display` commands",
-	Args:  cobra.MinimumNArgs(1),
+	Args:  cobra.MinimumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		consoleLogger := logger.NewConsoleLogger(logLevel)
 		consoleLogger.Info().Msg("Start scanning")
 
-		clientSource, err := (radix.PoolConfig{}).New(context.Background(), "tcp", args[0])
+		var redisUrl string
+		if len(args) > 0 {
+			redisUrl = args[0]
+		} else {
+			redisUrl = os.Getenv("REDIS_URL")
+		}
+
+		clientSource, err := (radix.PoolConfig{}).New(context.Background(), "tcp", redisUrl)
 		if err != nil {
 			consoleLogger.Fatal().Err(err).Msg("Can't create redis client")
 		}

--- a/cmd/app/vars.go
+++ b/cmd/app/vars.go
@@ -1,7 +1,7 @@
 package app
 
 var (
-	output, outputParams, separators, pattern string
-	maxChildren, scanCount, throttleNs        int
-	logLevel                                  string
+	output, outputParams, separators, pattern      string
+	maxChildren, scanCount, throttleNs, samplePerc int
+	logLevel                                       string
 )

--- a/src/adapter/rservice.go
+++ b/src/adapter/rservice.go
@@ -64,7 +64,7 @@ type BulkKeyInfo struct {
 
 // ScanKeys scans keys asynchroniously and sends them to the returned channel
 func (s RedisService) ScanKeys(ctx context.Context, options ScanOptions) <-chan BulkKeyInfo {
-	resultChan := make(chan BulkKeyInfo, options.ScanCount*2)
+	resultChan := make(chan BulkKeyInfo)
 
 	// if options.Pattern != "*" && options.Pattern != "" {
 	// 	scanOpts.Pattern = options.Pattern
@@ -87,8 +87,6 @@ func (s RedisService) ScanKeys(ctx context.Context, options ScanOptions) <-chan 
 				Keys:  make([]string, sampledKeyLength),
 				Sizes: make([]int64, sampledKeyLength),
 			}
-			// keys := make([]string, 0, len(scanRes.keys)/10+1)
-			// sizes := make([]string, 0, len(scanRes.keys)/10+1)
 			p := radix.NewPipeline()
 			for index, key := range scanRes.keys {
 				if index%100 < options.SamplePerc {

--- a/src/adapter/rservice_test.go
+++ b/src/adapter/rservice_test.go
@@ -2,10 +2,11 @@ package adapter
 
 import (
 	"context"
+	"testing"
+
 	"github.com/alicebob/miniredis/v2"
 	"github.com/mediocregopher/radix/v4"
 	"github.com/stretchr/testify/suite"
-	"testing"
 )
 
 type RedisServiceTestSuite struct {

--- a/src/renderer/chart.go
+++ b/src/renderer/chart.go
@@ -171,9 +171,11 @@ func (o anychartRenderer) render(result Node) (string, error) {
 
 				// configure tooltips
 				chart.tooltip().useHtml(true);
-				chart.tooltip().format(
-					"<span style='font-weight:bold'>{%pathFull}</span><br />{%valueHuman} in {%keys} keys"
-				);
+				chart.tooltip().format(function() {
+					const pathEscaped = this.getData("pathFull").replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+					return "<span style='font-weight:bold'>" + pathEscaped + "</span><br />" +
+						this.getData("valueHuman") +" in "+ this.getData("keys") +" keys";
+				});
 
 				// initiate drawing the chart
 				chart.draw();

--- a/src/renderer/chart.go
+++ b/src/renderer/chart.go
@@ -1,14 +1,15 @@
 package renderer
 
 import (
-	"code.cloudfoundry.org/bytefmt"
 	"encoding/json"
 	"errors"
+	"sort"
+	"strings"
+
+	"code.cloudfoundry.org/bytefmt"
 	"github.com/hetiansu5/urlquery"
 	"github.com/obukhov/redis-inventory/src/server"
 	"github.com/obukhov/redis-inventory/src/trie"
-	"sort"
-	"strings"
 )
 
 // NewChartRendererParams creates ChartRendererParams
@@ -85,7 +86,7 @@ func (o ChartRenderer) convertChildren(node *trie.Node, level int, prefix string
 
 		item := o.toNode(childNode, key, prefix)
 
-		if level < o.params.Depth && node.OverflowChildrenCount == 0 {
+		if level < o.params.Depth {
 			item.Children = o.convertChildren(childNode, nextLevel, prefix+key)
 		}
 
@@ -140,7 +141,7 @@ func (o anychartRenderer) render(result Node) (string, error) {
 			<script type="text/javascript">
 				// create data
 				var data = ` + string(s) + `;
-				const color = d3.scaleOrdinal(d3.schemePaired)
+				const color = d3.scaleOrdinal(d3.schemeCategory10)
 				// Free license provided for the project
 				anychart.licenseKey("redis-inventory-80818dc5-535fabc6");
 				// create a chart and set the data

--- a/src/renderer/table.go
+++ b/src/renderer/table.go
@@ -1,17 +1,18 @@
 package renderer
 
 import (
-	"code.cloudfoundry.org/bytefmt"
 	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+
+	"code.cloudfoundry.org/bytefmt"
 	"github.com/hetiansu5/urlquery"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/obukhov/redis-inventory/src/trie"
 	"golang.org/x/text/message"
-	"io"
-	"sort"
-	"strconv"
-	"strings"
 )
 
 var p = message.NewPrinter(message.MatchLanguage("en"))

--- a/src/scanner/scanner.go
+++ b/src/scanner/scanner.go
@@ -12,7 +12,6 @@ import (
 type RedisServiceInterface interface {
 	ScanKeys(ctx context.Context, options adapter.ScanOptions) <-chan adapter.BulkKeyInfo
 	GetKeysCount(ctx context.Context) (int64, error)
-	GetMemoryUsage(ctx context.Context, key string) (int64, error)
 }
 
 // RedisScanner scans redis keys and puts them in a trie
@@ -49,9 +48,9 @@ func (s *RedisScanner) Scan(options adapter.ScanOptions, result *trie.Trie) {
 				trie.ParamValue{Param: trie.KeysCount, Value: int64(100 / options.SamplePerc)},
 			)
 
-			if index%10 == 0 {
-				s.logger.Debug().Msgf("Dump %s value: %d", key, keyResult.Sizes[index])
-			}
+			// if index%10 == 0 {
+			// 	s.logger.Debug().Msgf("Dump %s value: %d", key, keyResult.Sizes[index])
+			// }
 		}
 	}
 	s.scanProgress.Stop()

--- a/src/scanner/scanner_test.go
+++ b/src/scanner/scanner_test.go
@@ -20,9 +20,9 @@ type RedisServiceMock struct {
 	mock.Mock
 }
 
-func (m *RedisServiceMock) ScanKeys(ctx context.Context, options adapter.ScanOptions) <-chan string {
+func (m *RedisServiceMock) ScanKeys(ctx context.Context, options adapter.ScanOptions) <-chan adapter.BulkKeyInfo {
 	args := m.Called(ctx, options)
-	return args.Get(0).(chan string)
+	return args.Get(0).(chan adapter.BulkKeyInfo)
 }
 
 func (m *RedisServiceMock) GetKeysCount(ctx context.Context) (int64, error) {

--- a/src/scanner/scanner_test.go
+++ b/src/scanner/scanner_test.go
@@ -3,8 +3,9 @@ package scanner
 import (
 	"context"
 	"errors"
-	"github.com/obukhov/redis-inventory/src/adapter"
 	"testing"
+
+	"github.com/obukhov/redis-inventory/src/adapter"
 
 	"github.com/obukhov/redis-inventory/src/trie"
 	"github.com/rs/zerolog"

--- a/src/scanner/scanner_test.go
+++ b/src/scanner/scanner_test.go
@@ -31,11 +31,6 @@ func (m *RedisServiceMock) GetKeysCount(ctx context.Context) (int64, error) {
 	return int64(args.Int(0)), args.Error(1)
 }
 
-func (m *RedisServiceMock) GetMemoryUsage(ctx context.Context, key string) (int64, error) {
-	args := m.Called(ctx, key)
-	return int64(args.Int(0)), args.Error(1)
-}
-
 type ProgressWriterMock struct {
 	mock.Mock
 }
@@ -66,9 +61,7 @@ func (suite *ScannerTestSuite) TestScan() {
 				Throttle:  0,
 			},
 		).
-		Return(scanChannel).
-		On("GetMemoryUsage", mock.Anything, "key1").Return(1, nil).
-		On("GetMemoryUsage", mock.Anything, "key2").Return(10, nil)
+		Return(scanChannel)
 
 	progressMock := &ProgressWriterMock{}
 	progressMock.
@@ -107,9 +100,7 @@ func (suite *ScannerTestSuite) TestScanWithPattern() {
 				Pattern:   "dev:*",
 			},
 		).
-		Return(scanChannel).
-		On("GetMemoryUsage", mock.Anything, "key1").Return(1, nil).
-		On("GetMemoryUsage", mock.Anything, "key2").Return(10, nil)
+		Return(scanChannel)
 
 	progressMock := &ProgressWriterMock{}
 	progressMock.
@@ -141,9 +132,7 @@ func (suite *ScannerTestSuite) TestScanWithError() {
 	redisMock := &RedisServiceMock{}
 	redisMock.
 		On("GetKeysCount", mock.Anything).Return(2, nil).
-		On("ScanKeys", mock.Anything, mock.Anything).Return(scanChannel).
-		On("GetMemoryUsage", mock.Anything, "key1").Return(1, errors.New("cannot get memory")).
-		On("GetMemoryUsage", mock.Anything, "key2").Return(10, nil)
+		On("ScanKeys", mock.Anything, mock.Anything).Return(scanChannel)
 
 	progressMock := &ProgressWriterMock{}
 	progressMock.
@@ -177,9 +166,7 @@ func (suite *ScannerTestSuite) TestScanCantGetCountKeys() {
 	redisMock := &RedisServiceMock{}
 	redisMock.
 		On("GetKeysCount", mock.Anything).Return(2, errors.New("cannot get count keys")).
-		On("ScanKeys", mock.Anything, mock.Anything).Return(scanChannel).
-		On("GetMemoryUsage", mock.Anything, "key1").Return(1, nil).
-		On("GetMemoryUsage", mock.Anything, "key2").Return(10, nil)
+		On("ScanKeys", mock.Anything, mock.Anything).Return(scanChannel)
 
 	progressMock := &ProgressWriterMock{}
 	progressMock.

--- a/src/trie/trie.go
+++ b/src/trie/trie.go
@@ -19,11 +19,30 @@ type Trie struct {
 	maxChildren int
 }
 
+func digitPrefix(key string) int {
+	lastDigit := -1
+	for index, c := range key {
+		if c < '0' || c > '9' {
+			lastDigit = index
+			break
+		}
+	}
+
+	return lastDigit
+}
+
 // Add adds information about another key with set of params
 func (t *Trie) Add(key string, paramValues ...ParamValue) {
 	curNode := t.root
 	for _, keyPiece := range t.splitter.Split(key) { // change to zero allocation segmenter
 		var nextNode *Node
+
+		prefix := digitPrefix(keyPiece)
+		if prefix > 0 {
+			keyPiece = "<id>" + keyPiece[prefix:]
+		} else if prefix == -1 {
+			keyPiece = "<id>"
+		}
 
 		if childNode := curNode.GetChild(keyPiece); childNode == nil {
 			if curNode.ChildCount() == 1 {

--- a/src/trie/trie_test.go
+++ b/src/trie/trie_test.go
@@ -1,9 +1,10 @@
 package trie
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"testing"
 )
 
 type TrieTestSuite struct {
@@ -38,6 +39,21 @@ func (suite *TrieTestSuite) TestKeyEndingInFork() {
 	// fork node
 	assert.NotNil(suite.T(), trie.root.Children["foo:"].Children["bar:"].Aggr, "Fork node has where key ended")
 	assert.Equal(suite.T(), int64(130), trie.root.Children["foo:"].Children["bar:"].Aggr.Params[BytesSize], "Fork node aggregated value is 130")
+}
+
+func (suite *TrieTestSuite) TestIDsEndingInFork() {
+	trie := NewTrie(NewPunctuationSplitter(':'), 100)
+
+	trie.Add("123123:bar:lorem", ParamValue{BytesSize, 10})
+	trie.Add("234234:bar:ipsum", ParamValue{BytesSize, 20})
+	trie.Add("234:bar:", ParamValue{BytesSize, 100})
+	// root node
+	assert.Equal(suite.T(), int64(130), trie.root.Aggr.Params[BytesSize], "Root node aggregated value is 130")
+	// intermediate node
+	assert.Nil(suite.T(), trie.root.Children["<id>:"].Aggr, "Intermediate node skip aggregation if has just one child")
+	// fork node
+	assert.NotNil(suite.T(), trie.root.Children["<id>:"].Children["bar:"].Aggr, "Fork node has where key ended")
+	assert.Equal(suite.T(), int64(130), trie.root.Children["<id>:"].Children["bar:"].Aggr.Params[BytesSize], "Fork node aggregated value is 130")
 }
 
 func (suite *TrieTestSuite) TestKeyEndingInIntermediateNode() {


### PR DESCRIPTION
batch pipelining reduced the time it took to execute the code by ~40x and sampling in theory can reduce it further (in practice if you're keeping the KEYS count fixed and if your redis response time is >>> dominated by your RTT latency sampling doesn't matter at all)